### PR TITLE
Make manifest field conditional on cli version>=3.2.0

### DIFF
--- a/app_basic/snowflake.yml
+++ b/app_basic/snowflake.yml
@@ -13,11 +13,12 @@ entities:
   pkg:
     type: application package
     identifier: <% fn.concat_ids('<! project_name | to_snowflake_identifier !>_pkg', ctx.env.suffix) %>
-    manifest: app/manifest.yml
     artifacts:
       - src: app/*
         dest: ./
-
+    <!! if snowflake_cli_version < "3.2.0" !!>
+    manifest: app/manifest.yml
+    <!! endif !!>
   app:
     type: application
     from:

--- a/app_spcs_basic/snowflake.yml
+++ b/app_spcs_basic/snowflake.yml
@@ -13,10 +13,12 @@ entities:
   pkg:
     type: application package
     identifier: <% fn.concat_ids('<! project_name | to_snowflake_identifier !>_pkg', ctx.env.suffix) %>
-    manifest: app/manifest.yml
     artifacts:
       - src: app/*
         dest: ./
+    <!! if snowflake_cli_version < "3.2.0" !!>
+    manifest: app/manifest.yml
+    <!! endif !!>
 
   app:
     type: application

--- a/app_streamlit_java/snowflake.yml
+++ b/app_streamlit_java/snowflake.yml
@@ -17,7 +17,6 @@ entities:
   pkg:
     type: application package
     identifier: <% fn.concat_ids('<! project_name | to_snowflake_identifier !>_pkg', ctx.env.suffix) %>
-    manifest: app/manifest.yml
     artifacts:
       - src: app/*
         dest: ./
@@ -25,6 +24,9 @@ entities:
         dest: module-add/add-1.0-SNAPSHOT.jar
       - src: src/module-ui/src/*
         dest: streamlit/
+    <!! if snowflake_cli_version < "3.2.0" !!>
+    manifest: app/manifest.yml
+    <!! endif !!>
 
   app:
     type: application

--- a/app_streamlit_js/snowflake.yml
+++ b/app_streamlit_js/snowflake.yml
@@ -15,12 +15,14 @@ entities:
   pkg:
     type: application package
     identifier: <% fn.concat_ids('<! project_name | to_snowflake_identifier !>_pkg', ctx.env.suffix) %>
-    manifest: app/manifest.yml
     artifacts:
       - src: app/*
         dest: ./
       - src: src/module-ui/src/*
         dest: streamlit/
+    <!! if snowflake_cli_version < "3.2.0" !!>
+    manifest: app/manifest.yml
+    <!! endif !!>
 
   app:
     type: application

--- a/app_streamlit_python/snowflake.yml
+++ b/app_streamlit_python/snowflake.yml
@@ -17,7 +17,6 @@ entities:
   pkg:
     type: application package
     identifier: <% fn.concat_ids('<! project_name | to_snowflake_identifier !>_pkg', ctx.env.suffix) %>
-    manifest: app/manifest.yml
     artifacts:
       - src: app/*
         dest: ./
@@ -25,6 +24,9 @@ entities:
         dest: module-add/add.py
       - src: src/module-ui/src/*
         dest: streamlit/
+    <!! if snowflake_cli_version < "3.2.0" !!>
+    manifest: app/manifest.yml
+    <!! endif !!>
 
   app:
     type: application


### PR DESCRIPTION
`manifest` in `application package` entity is optional as of 3.2.0, and has no functionality. Therefore the templates should not generate that field for pdfV2 projects.  